### PR TITLE
Fix ALIGNOF macro on recent compilers

### DIFF
--- a/include/relf.h
+++ b/include/relf.h
@@ -140,7 +140,13 @@ unsigned char *get_dynstr(struct LINK_MAP_STRUCT_TAG *l);
 
 
 #ifndef ALIGNOF
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+#define ALIGNOF _Alignof
+#elif defined(__cplusplus) && __cplusplus >= 201103L
+#define ALIGNOF alignof
+#else
 #define ALIGNOF(t) offsetof (struct { char c; t memb; }, memb)
+#endif
 #endif
 
 /* Although we have no intention of modifying the strings in 'environ',


### PR DESCRIPTION
The ALIGNOF macro as defined does not work on recent compilers like GCC 8.3.
But these compiler support the _Alignof keyword. Therefore, we are now using the keyword instead of the offsetof trick, when it is available.